### PR TITLE
Create reusable mui tree component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "mui-reusable-tree",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "@mui/material": "^5.16.7",
+    "@mui/system": "^5.16.7",
+    "@mui/icons-material": "^5.16.7",
+    "@mui/x-tree-view": "^7.9.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.5.4",
+    "vite": "^5.4.0",
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7"
+  }
+}

--- a/src/components/Tree/CustomTreeItem.tsx
+++ b/src/components/Tree/CustomTreeItem.tsx
@@ -1,0 +1,138 @@
+import React, { memo, useMemo } from 'react';
+import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import Chip from '@mui/material/Chip';
+import Tooltip from '@mui/material/Tooltip';
+import Collapse from '@mui/material/Collapse';
+import { TreeItem } from '@mui/x-tree-view/TreeItem';
+import type { CustomTreeItemProps, TreeDataNode } from './types';
+import { defaultGetChildren, hasChildren, mergeSx, shallowEqual, statusToPaletteColor } from './utils';
+import { chipSx, iconContainerSx, labelSx, statusDotSx, treeItemContentBaseSx, highlightLeftBorder } from './styles';
+import { useTheme } from '@mui/material/styles';
+
+function DefaultLabel<TNode extends TreeDataNode>({ node }: { node: TNode }) {
+  const theme = useTheme();
+  const meta = node.meta as any;
+  const paletteKey = statusToPaletteColor(meta?.status);
+  const color = paletteKey ? theme.palette[paletteKey].main : theme.palette.text.disabled;
+
+  return (
+    <Stack direction="row" alignItems="center" spacing={1} sx={{ minWidth: 0, flex: 1 }}>
+      {meta?.icon && <Box sx={{ display: 'flex', alignItems: 'center' }}>{meta.icon}</Box>}
+      <Typography variant="body2" noWrap title={node.label} sx={{ fontWeight: 500 }}>
+        {node.label}
+      </Typography>
+      <Box sx={{ flex: 1 }} />
+      {typeof meta?.distance !== 'undefined' && (
+        <Typography variant="caption" color="text.secondary">{String(meta.distance)}</Typography>
+      )}
+      {meta?.status && <Box sx={statusDotSx(color)} />}
+      {meta?.matched && (
+        <Chip size="small" label={meta.matched} color="success" variant="outlined" sx={chipSx} />
+      )}
+      {Array.isArray(meta?.chips) && meta!.chips!.map((c: any, idx: number) => (
+        <Chip key={idx} size="small" label={c.label} color={c.color} variant={c.variant ?? 'filled'} sx={chipSx} />
+      ))}
+      {Array.isArray(meta?.actions) && meta!.actions!.map((a: any) => (
+        <Tooltip key={a.id} title={a.tooltip ?? ''}>
+          <Box
+            onClick={(e) => {
+              if (a.stopPropagation) {
+                e.stopPropagation();
+                e.preventDefault();
+              }
+              a.onClick?.(node as any, e);
+            }}
+            sx={{ display: 'flex', alignItems: 'center', cursor: 'pointer', color: 'text.secondary' }}
+            aria-label={a.id}
+            role="button"
+          >
+            {a.icon}
+          </Box>
+        </Tooltip>
+      ))}
+    </Stack>
+  );
+}
+
+function EmptyEndIcon() {
+  return <Box sx={{ width: 18, height: 18 }} />;
+}
+
+function _CustomTreeItem<TMeta, TNode extends TreeDataNode<TMeta>>({
+  node,
+  renderLabel,
+  getChildren,
+  nodeContentSx,
+  collapseIcon,
+  expandIcon,
+  endIcon,
+}: CustomTreeItemProps<TMeta, TNode>) {
+  const children = (getChildren ?? (defaultGetChildren as any))(node) ?? [];
+  const isLeaf = !hasChildren(node as any, getChildren as any) || node.isLeaf;
+
+  const contentSx = useMemo(
+    () => mergeSx(treeItemContentBaseSx, highlightLeftBorder(node.meta as any), nodeContentSx?.(node as any)),
+    [node, nodeContentSx]
+  );
+
+  const labelEl = useMemo(() => {
+    return renderLabel ? renderLabel(node) : <DefaultLabel node={node} />;
+  }, [node, renderLabel]);
+
+  return (
+    <TreeItem
+      itemId={node.id}
+      label={labelEl}
+      disabled={node.disabled}
+      slots={{
+        groupTransition: Collapse,
+      }}
+      slotProps={{
+        content: { sx: contentSx },
+        iconContainer: { sx: iconContainerSx },
+        label: { sx: labelSx },
+      }}
+      collapseIcon={collapseIcon}
+      expandIcon={expandIcon}
+      endIcon={isLeaf ? endIcon ?? <EmptyEndIcon /> : undefined}
+    >
+      {children.map((child) => (
+        <MemoCustomTreeItem
+          key={child.id}
+          node={child as any}
+          renderLabel={renderLabel as any}
+          getChildren={getChildren as any}
+          nodeContentSx={nodeContentSx as any}
+          collapseIcon={collapseIcon}
+          expandIcon={expandIcon}
+          endIcon={endIcon}
+        />
+      ))}
+    </TreeItem>
+  );
+}
+
+function arePropsEqual<TMeta, TNode extends TreeDataNode<TMeta>>(
+  prev: Readonly<CustomTreeItemProps<TMeta, TNode>>,
+  next: Readonly<CustomTreeItemProps<TMeta, TNode>>
+) {
+  const a = prev.node;
+  const b = next.node;
+  if (a === b) return true;
+  if (a.id !== b.id) return false;
+  if (a.label !== b.label) return false;
+  if (!shallowEqual(a.meta as any, b.meta as any)) return false;
+  const aLen = (a.children?.length ?? 0);
+  const bLen = (b.children?.length ?? 0);
+  if (aLen !== bLen) return false;
+  return true;
+}
+
+export const MemoCustomTreeItem = memo(_CustomTreeItem as any, arePropsEqual as any) as <
+  TMeta,
+  TNode extends TreeDataNode<TMeta>
+>(props: CustomTreeItemProps<TMeta, TNode>) => JSX.Element;
+
+export default MemoCustomTreeItem;

--- a/src/components/Tree/ExampleTreeUsage.tsx
+++ b/src/components/Tree/ExampleTreeUsage.tsx
@@ -1,0 +1,179 @@
+import React, { useMemo, useState } from 'react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Chip from '@mui/material/Chip';
+import Stack from '@mui/material/Stack';
+import PlaceIcon from '@mui/icons-material/Place';
+import MapIcon from '@mui/icons-material/Map';
+import LinkIcon from '@mui/icons-material/Link';
+import ReplayIcon from '@mui/icons-material/Replay';
+import CheckIcon from '@mui/icons-material/Check';
+import WarningAmberIcon from '@mui/icons-material/WarningAmber';
+import { SxProps, Theme } from '@mui/material/styles';
+import Tree from './Tree';
+import type { NodeMeta, TreeDataNode } from './types';
+
+interface DemoMeta extends NodeMeta {
+  kind: 'field' | 'pad' | 'well';
+}
+
+function makeNode(
+  id: string,
+  label: string,
+  meta: Partial<DemoMeta> = {},
+  children?: TreeDataNode<DemoMeta>[]
+): TreeDataNode<DemoMeta> {
+  return { id, label, meta: meta as DemoMeta, children };
+}
+
+export default function ExampleTreeUsage() {
+  const data = useMemo<TreeDataNode<DemoMeta>[]>(
+    () => [
+      makeNode(
+        'field-1',
+        'Восточно-Мессоякское месторождение',
+        {
+          kind: 'field',
+          distance: '2850m',
+          status: 'active',
+          matched: 'SAP',
+          chips: [{ label: 'Сопоставлено', color: 'success', variant: 'outlined' }],
+          actions: [
+            { id: 'refresh', icon: <ReplayIcon fontSize="small" />, tooltip: 'Обновить' },
+          ],
+        },
+        [
+          makeNode(
+            'pad-1',
+            'Куст BM-A',
+            {
+              kind: 'pad',
+              distance: '2850m',
+              status: 'active',
+              matched: 'SAP',
+            },
+            [
+              makeNode('well-1', 'Скважина BM-001', {
+                kind: 'well',
+                distance: '2850m',
+                status: 'active',
+                matched: 'WellDB',
+                chips: [{ label: 'Сопоставлено', color: 'success' }],
+              }),
+              makeNode('well-2', 'Скважина BM-002', {
+                kind: 'well',
+                distance: '2650m',
+                status: 'warning',
+                chips: [{ label: 'Конфликт', color: 'warning', variant: 'outlined' }],
+                matched: 'WellDB',
+                highlight: { color: '#f7b500' },
+              }),
+              makeNode('well-3', 'Скважина BM-003', {
+                kind: 'well',
+                distance: '2780m',
+                status: 'active',
+                chips: [{ label: 'Сопоставлено', color: 'success' }],
+                matched: 'WellDB',
+              }),
+            ]
+          ),
+          makeNode(
+            'pad-2',
+            'Куст BM-Б',
+            { kind: 'pad', distance: '2650m', status: 'inactive', chips: [{ label: 'Частично', color: 'info', variant: 'outlined' }] }
+          ),
+        ]
+      ),
+      makeNode(
+        'field-2',
+        'Сургутское месторождение',
+        {
+          kind: 'field',
+          distance: '3200m',
+          status: 'active',
+          chips: [{ label: 'Сопоставлено', color: 'success', variant: 'outlined' }],
+          matched: 'SAP',
+        },
+        [
+          makeNode(
+            'pad-3',
+            'Куст СГ-Северный',
+            { kind: 'pad', distance: '3200m', status: 'active', chips: [{ label: 'Частично', color: 'info', variant: 'outlined' }] }
+          ),
+        ]
+      ),
+      makeNode(
+        'field-3',
+        'Красноленинское месторождение',
+        {
+          kind: 'field',
+          distance: '2950m',
+          status: 'active',
+          chips: [{ label: 'Не сопоставлено', color: 'default', variant: 'outlined' }],
+        }
+      ),
+      makeNode(
+        'field-4',
+        'Южное месторождение',
+        { kind: 'field', distance: '2400m', status: 'inactive', chips: [{ label: 'Не сопоставлено', variant: 'outlined' }] }
+      ),
+    ],
+    []
+  );
+
+  const [expanded, setExpanded] = useState<string[]>(['field-1', 'pad-1']);
+  const [selected, setSelected] = useState<string | string[]>('well-1');
+
+  const renderLabel = (node: TreeDataNode<DemoMeta>) => {
+    return (
+      <Stack direction="row" alignItems="center" sx={{ minWidth: 0, flex: 1 }} spacing={1}>
+        {node.meta?.kind === 'field' && <MapIcon fontSize="small" />}
+        {node.meta?.kind === 'pad' && <PlaceIcon fontSize="small" />}
+        {node.meta?.kind === 'well' && <CheckIcon fontSize="small" />}
+        <Typography variant="body2" noWrap sx={{ fontWeight: 500 }}>
+          {node.label}
+        </Typography>
+        <Box sx={{ flex: 1 }} />
+        {node.meta?.distance && (
+          <Typography variant="caption" color="text.secondary">{String(node.meta.distance)}</Typography>
+        )}
+        {node.meta?.matched && (
+          <Chip size="small" label={node.meta.matched} color="success" variant="outlined" />
+        )}
+        {node.meta?.chips?.map((c, i) => (
+          <Chip key={i} size="small" label={c.label} color={c.color} variant={c.variant} />
+        ))}
+        <LinkIcon fontSize="small" />
+      </Stack>
+    );
+  };
+
+  const nodeContentSx = (node: TreeDataNode<DemoMeta>): SxProps<Theme> => {
+    if (node.meta?.highlight) {
+      return (theme) => ({ boxShadow: `inset 2px 0 0 0 ${theme.palette.warning.main}` });
+    }
+    return {};
+  };
+
+  return (
+    <Box sx={{ p: 2 }}>
+      <Typography variant="h6" gutterBottom>
+        Пример дерева
+      </Typography>
+
+      <Tree<DemoMeta, TreeDataNode<DemoMeta>>
+        data={data}
+        renderLabel={renderLabel}
+        defaultExpanded={['field-1']}
+        expanded={expanded}
+        onExpandedItemsChange={(_, ids) => setExpanded(ids)}
+        defaultSelectedItems="well-1"
+        selected={selected}
+        onSelectedItemsChange={(_, ids) => setSelected(ids)}
+        multiSelect
+        nodeContentSx={nodeContentSx}
+        sx={{ maxWidth: 900 }}
+      />
+    </Box>
+  );
+}

--- a/src/components/Tree/Tree.tsx
+++ b/src/components/Tree/Tree.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { SimpleTreeView } from '@mui/x-tree-view/SimpleTreeView';
+import type { TreeProps, TreeDataNode } from './types';
+import { defaultGetChildren } from './utils';
+import { treeSx } from './styles';
+import MemoCustomTreeItem from './CustomTreeItem';
+
+function Tree<TMeta, TNode extends TreeDataNode<TMeta>>({
+  data,
+  renderLabel,
+  getChildren = defaultGetChildren as any,
+  defaultExpanded,
+  expanded,
+  onExpandedItemsChange,
+  defaultSelectedItems,
+  selected,
+  onSelectedItemsChange,
+  multiSelect,
+  nodeContentSx,
+  sx,
+  collapseIcon,
+  expandIcon,
+  endIcon,
+}: TreeProps<TMeta, TNode>) {
+  return (
+    <SimpleTreeView
+      defaultExpandedItems={defaultExpanded}
+      expandedItems={expanded}
+      onExpandedItemsChange={onExpandedItemsChange as any}
+      defaultSelectedItems={defaultSelectedItems as any}
+      selectedItems={selected as any}
+      onSelectedItemsChange={onSelectedItemsChange as any}
+      multiSelect={multiSelect}
+      slots={{
+        collapseIcon: collapseIcon ? () => <>{collapseIcon}</> : undefined,
+        expandIcon: expandIcon ? () => <>{expandIcon}</> : undefined,
+        endIcon: endIcon ? () => <>{endIcon}</> : undefined,
+      }}
+      sx={[treeSx as any, sx as any]}
+    >
+      {data.map((node) => (
+        <MemoCustomTreeItem
+          key={node.id}
+          node={node as any}
+          renderLabel={renderLabel as any}
+          getChildren={getChildren as any}
+          nodeContentSx={nodeContentSx as any}
+          collapseIcon={collapseIcon}
+          expandIcon={expandIcon}
+          endIcon={endIcon}
+        />
+      ))}
+    </SimpleTreeView>
+  );
+}
+
+export default Tree as unknown as <TMeta, TNode extends TreeDataNode<TMeta>>(
+  props: TreeProps<TMeta, TNode>
+) => JSX.Element;

--- a/src/components/Tree/styles.ts
+++ b/src/components/Tree/styles.ts
@@ -1,0 +1,81 @@
+import type { SxProps, Theme } from '@mui/material/styles';
+import { alpha } from '@mui/material/styles';
+import type { NodeMeta } from './types';
+
+export const treeSx: SxProps<Theme> = (theme) => ({
+  bgcolor: 'background.default',
+  color: 'text.primary',
+  p: 0,
+  '& .MuiTreeItem-root': {
+    // spacing between items
+    my: 0.5,
+  },
+  '& .Mui-selected > .MuiTreeItem-content, & .MuiTreeItem-content.Mui-selected': {
+    bgcolor: alpha(theme.palette.primary.main, 0.12),
+  },
+  '& .MuiTreeItem-content:hover': {
+    bgcolor: alpha(theme.palette.primary.main, 0.06),
+  },
+  '& .Mui-focused > .MuiTreeItem-content, & .MuiTreeItem-content.Mui-focused': {
+    outline: `2px solid ${alpha(theme.palette.primary.main, 0.5)}`,
+    outlineOffset: -2,
+  },
+});
+
+export const treeItemContentBaseSx: SxProps<Theme> = (theme) => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 1,
+  px: 1,
+  py: 0.5,
+  borderRadius: 1,
+  border: `1px solid ${alpha(theme.palette.common.white, 0.08)}`,
+  bgcolor: alpha(theme.palette.common.white, 0.02),
+});
+
+export const labelSx: SxProps<Theme> = {
+  flex: 1,
+  minWidth: 0,
+  display: 'flex',
+  alignItems: 'center',
+  gap: 1,
+};
+
+export const iconContainerSx: SxProps<Theme> = (theme) => ({
+  color: alpha(theme.palette.text.primary, 0.7),
+});
+
+export const chipSx: SxProps<Theme> = (theme) => ({
+  height: 24,
+  '& .MuiChip-label': { px: 1 },
+});
+
+export function highlightLeftBorder(meta?: NodeMeta): SxProps<Theme> | undefined {
+  if (!meta || !meta.highlight) return undefined;
+  const cfg = meta.highlight;
+  const thickness = typeof cfg === 'object' ? cfg.thickness ?? 2 : 2;
+  const color = typeof cfg === 'object' ? cfg.color : undefined;
+  return (theme) => ({
+    position: 'relative',
+    '&::before': {
+      content: '""',
+      position: 'absolute',
+      left: -4,
+      top: 2,
+      bottom: 2,
+      width: thickness,
+      borderRadius: 2,
+      bgcolor: color ?? theme.palette.warning.main,
+    },
+  });
+}
+
+export function statusDotSx(color: string): SxProps<Theme> {
+  return {
+    width: 8,
+    height: 8,
+    borderRadius: '50%',
+    bgcolor: color,
+    display: 'inline-block',
+  };
+}

--- a/src/components/Tree/types.ts
+++ b/src/components/Tree/types.ts
@@ -1,0 +1,99 @@
+import type { ReactNode, SyntheticEvent } from 'react';
+import type { SxProps, Theme } from '@mui/material/styles';
+
+export type TreeStatus =
+  | 'active'
+  | 'stopped'
+  | 'partial'
+  | 'warning'
+  | 'error'
+  | 'success'
+  | 'inactive';
+
+export interface NodeAction<TNode extends TreeDataNode = TreeDataNode> {
+  id: string;
+  icon: ReactNode;
+  tooltip?: string;
+  onClick?: (node: TNode, event: SyntheticEvent) => void;
+  stopPropagation?: boolean;
+}
+
+export interface ChipMeta {
+  label: string;
+  color?: 'default' | 'primary' | 'secondary' | 'success' | 'info' | 'warning' | 'error';
+  variant?: 'filled' | 'outlined';
+}
+
+export interface NodeMeta<TExtra = unknown> {
+  distance?: string | number;
+  status?: TreeStatus;
+  statusDotColor?: string; // override color for status dot
+  matched?: string; // e.g. "SAP", "WellDB"
+  subtitle?: string;
+  chips?: ChipMeta[]; // right side chips/badges
+  highlight?: false | 'primary' | 'warning' | 'success' | 'error' | 'info' | 'danger' | { color: string; thickness?: number };
+  actions?: NodeAction[]; // right side action icons
+  icon?: ReactNode; // left icon near label
+  endIcon?: ReactNode; // per-node end icon override
+  extra?: TExtra; // any domain-specific meta
+}
+
+export interface TreeDataNode<TMeta = NodeMeta> {
+  id: string;
+  label?: string; // used only if renderLabel is not provided
+  meta?: TMeta;
+  children?: TreeDataNode<TMeta>[];
+  isLeaf?: boolean; // forces leaf behavior even if children present later (for lazy)
+  disabled?: boolean;
+}
+
+export type GetChildren<TNode extends TreeDataNode> = (node: TNode) => TNode[] | undefined;
+
+export type RenderLabel<TNode extends TreeDataNode> = (node: TNode) => ReactNode;
+
+export type ExpandedChangeHandler = (
+  event: SyntheticEvent,
+  itemIds: string[]
+) => void;
+
+export type SelectedChangeHandler = (
+  event: SyntheticEvent,
+  itemIds: string[] | string
+) => void;
+
+export interface TreeSlots {
+  collapseIcon?: ReactNode;
+  expandIcon?: ReactNode;
+  endIcon?: ReactNode;
+}
+
+export interface TreeProps<
+  TMeta = NodeMeta,
+  TNode extends TreeDataNode<TMeta> = TreeDataNode<TMeta>
+> extends TreeSlots {
+  data: TNode[];
+  renderLabel?: RenderLabel<TNode>;
+  getChildren?: GetChildren<TNode>;
+
+  defaultExpanded?: string[];
+  expanded?: string[];
+  onExpandedItemsChange?: ExpandedChangeHandler;
+
+  defaultSelectedItems?: string | string[];
+  selected?: string | string[];
+  onSelectedItemsChange?: SelectedChangeHandler;
+
+  multiSelect?: boolean;
+  nodeContentSx?: (node: TNode) => SxProps<Theme>;
+  sx?: SxProps<Theme>;
+}
+
+export interface CustomTreeItemProps<
+  TMeta = NodeMeta,
+  TNode extends TreeDataNode<TMeta> = TreeDataNode<TMeta>
+> extends TreeSlots {
+  node: TNode;
+  renderLabel?: RenderLabel<TNode>;
+  getChildren?: GetChildren<TNode>;
+  nodeContentSx?: (node: TNode) => SxProps<Theme>;
+}

--- a/src/components/Tree/utils.ts
+++ b/src/components/Tree/utils.ts
@@ -1,0 +1,53 @@
+import type { SxProps, Theme } from '@mui/material/styles';
+import type { GetChildren, TreeDataNode, TreeStatus } from './types';
+
+export function defaultGetChildren<TNode extends TreeDataNode>(node: TNode): TNode[] | undefined {
+  return (node.children as TNode[] | undefined) ?? undefined;
+}
+
+export function hasChildren<TNode extends TreeDataNode>(
+  node: TNode,
+  getChildren?: GetChildren<TNode>
+): boolean {
+  const children = (getChildren ?? defaultGetChildren)(node) ?? [];
+  return children.length > 0;
+}
+
+export function mergeSx(
+  ...sxList: Array<SxProps<Theme> | undefined>
+): SxProps<Theme> | undefined {
+  const filtered = sxList.filter(Boolean) as SxProps<Theme>[];
+  if (filtered.length === 0) return undefined;
+  if (filtered.length === 1) return filtered[0];
+  return filtered; // MUI sx accepts arrays to merge
+}
+
+export function statusToPaletteColor(status?: TreeStatus): keyof Theme['palette'] | undefined {
+  switch (status) {
+    case 'success':
+    case 'active':
+      return 'success';
+    case 'warning':
+    case 'partial':
+      return 'warning';
+    case 'error':
+      return 'error';
+    case 'stopped':
+    case 'inactive':
+      return 'grey';
+    default:
+      return undefined;
+  }
+}
+
+export function shallowEqual<T extends Record<string, unknown>>(a?: T, b?: T): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+  if (aKeys.length !== bKeys.length) return false;
+  for (const key of aKeys) {
+    if (a[key] !== b[key]) return false;
+  }
+  return true;
+}


### PR DESCRIPTION
Create a reusable, typed React `<Tree>` component based on `@mui/x/react-tree-view` to provide a flexible and production-ready tree view with a customizable API and visual appearance.

---
<a href="https://cursor.com/background-agent?bcId=bc-3ceec272-cdc8-45fc-a8bc-2e21c7a7bf59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3ceec272-cdc8-45fc-a8bc-2e21c7a7bf59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

