### PR TITLE
Create reusable mui tree component

### DIFF
--- a/src/components/Tree/CustomTreeItem.tsx
+++ b/src/components/Tree/CustomTreeItem.tsx
@@ -1,0 +1,144 @@
+import React from 'react';
+import Collapse from '@mui/material/Collapse';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import { TreeItem } from '@mui/x-tree-view/TreeItem';
+import type { CustomTreeItemProps, TreeDataNode } from './types';
+import { defaultGetChildren, hasChildren, mergeSx } from './utils';
+import {
+  labelSx,
+  treeItemContentBaseSx,
+  iconContainerSx,
+  statusDotSx,
+  chipSx,
+  nodeRightActionsSx,
+  emptyEndIconBoxSx,
+  nodeContentComposeSx,
+} from './styles';
+
+// Default label view resembling the screenshot, customizable via renderLabel prop
+const DefaultLabel: React.FC<{ node: TreeDataNode }> = ({ node }) => {
+  const distance = node.meta?.distanceMeters != null ? `${node.meta?.distanceMeters}m` : undefined;
+  return (
+    <Box sx={labelSx}>
+      <Box className="TreeLabel-left">
+        {/* Status dot */}
+        <Box
+          sx={statusDotSx}
+          className={node.meta?.activity === 'active' ? 'active' : node.meta?.activity === 'stopped' ? 'stopped' : undefined}
+        />
+        <Box minWidth={0}>
+          <Typography variant="body2" className="TreeLabel-title" title={node.label}>
+            {node.label}
+          </Typography>
+          {node.meta?.subtitle && (
+            <Typography variant="caption" className="TreeLabel-subtitle">
+              {node.meta.subtitle}
+            </Typography>
+          )}
+        </Box>
+      </Box>
+      <Box className="TreeLabel-right">
+        {distance && (
+          <Typography variant="caption" sx={{ opacity: 0.7 }}>
+            {distance}
+          </Typography>
+        )}
+        {node.meta?.match && (
+          <Box component="span" sx={chipSx}>
+            {node.meta.match === 'matched' ? 'Сопоставлено' : node.meta.match === 'partially' ? 'Частично' : 'Не сопоставлено'}
+          </Box>
+        )}
+        {node.meta?.matchSourceLabel && (
+          <Box component="span" sx={chipSx}>
+            {node.meta.matchSourceLabel}
+          </Box>
+        )}
+        {!!node.meta?.actions?.length && (
+          <Box sx={nodeRightActionsSx}>
+            {node.meta.actions.map((a) => (
+              <Box
+                key={a.id}
+                className="TreeAction"
+                aria-disabled={a.disabled ? 'true' : undefined}
+                onClick={(e) => a.onClick?.(node, e)}
+                title={a.title}
+              >
+                {a.icon}
+              </Box>
+            ))}
+          </Box>
+        )}
+      </Box>
+    </Box>
+  );
+};
+
+const CustomTreeItemComponent: React.FC<CustomTreeItemProps> = ({
+  node,
+  getChildren = defaultGetChildren,
+  renderLabel,
+  nodeContentSx,
+  collapseIcon,
+  expandIcon,
+  endIcon,
+}) => {
+  const children = getChildren(node) ?? [];
+  const leaf = children.length === 0;
+
+  const label = renderLabel ? renderLabel(node) : <DefaultLabel node={node} />;
+
+  return (
+    <TreeItem
+      itemId={node.id}
+      label={label}
+      slots={{
+        groupTransition: Collapse,
+      }}
+      slotProps={{
+        content: {
+          sx: nodeContentComposeSx(node, treeItemContentBaseSx, nodeContentSx?.(node)),
+        },
+        label: { sx: mergeSx(undefined, undefined) },
+        iconContainer: { sx: iconContainerSx },
+      }}
+      collapseIcon={collapseIcon}
+      expandIcon={expandIcon}
+      endIcon={leaf ? (endIcon ?? <Box component="span" sx={emptyEndIconBoxSx} />) : undefined}
+    >
+      {children.map((child) => (
+        <MemoCustomTreeItem
+          key={child.id}
+          node={child}
+          getChildren={getChildren}
+          renderLabel={renderLabel}
+          nodeContentSx={nodeContentSx}
+          collapseIcon={collapseIcon}
+          expandIcon={expandIcon}
+          endIcon={endIcon}
+        />
+      ))}
+    </TreeItem>
+  );
+};
+
+const areEqual = (prev: CustomTreeItemProps, next: CustomTreeItemProps) => {
+  if (prev.node.id !== next.node.id) return false;
+  // Shallow compare references for performance; assume upstream memoization for deep fields if needed
+  if (prev.node === next.node) return true;
+  // Compare a few common meta fields that frequently change
+  const pm = prev.node.meta;
+  const nm = next.node.meta;
+  return (
+    pm?.distanceMeters === nm?.distanceMeters &&
+    pm?.activity === nm?.activity &&
+    pm?.match === nm?.match &&
+    pm?.matchSourceLabel === nm?.matchSourceLabel &&
+    pm?.subtitle === nm?.subtitle &&
+    pm?.highlight === nm?.highlight &&
+    (pm?.actions?.length ?? 0) === (nm?.actions?.length ?? 0)
+  );
+};
+
+export const MemoCustomTreeItem = React.memo(CustomTreeItemComponent, areEqual);
+export default MemoCustomTreeItem;

--- a/src/components/Tree/ExampleTreeUsage.tsx
+++ b/src/components/Tree/ExampleTreeUsage.tsx
@@ -1,0 +1,182 @@
+import React from 'react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import IconButton from '@mui/material/IconButton';
+import LinkIcon from '@mui/icons-material/Link';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+import CheckIcon from '@mui/icons-material/CheckCircleOutline';
+import WarningAmberIcon from '@mui/icons-material/WarningAmber';
+import Tree from './Tree';
+import type { TreeDataNode } from './types';
+import { chipSx, statusDotSx } from './styles';
+
+const data: TreeDataNode[] = [
+  {
+    id: 'field-bm',
+    label: 'Восточно-Мессояхское месторождение',
+    meta: { distanceMeters: 2850, activity: 'active', match: 'matched', matchSourceLabel: 'SAP' },
+    children: [
+      {
+        id: 'pad-bm-a',
+        label: 'Куст BM-A',
+        meta: { distanceMeters: 2850, activity: 'active', match: 'matched', matchSourceLabel: 'SAP' },
+        children: [
+          {
+            id: 'well-bm-001',
+            label: 'Скважина BM-001',
+            meta: {
+              distanceMeters: 2850,
+              activity: 'active',
+              match: 'matched',
+              matchSourceLabel: 'WellDB',
+              subtitle: 'Активно',
+              actions: [
+                {
+                  id: 'link',
+                  icon: <LinkIcon fontSize="small" />,
+                  title: 'Открыть связь',
+                  onClick: (node) => console.log('link', node.id),
+                },
+              ],
+            },
+          },
+          {
+            id: 'well-bm-002',
+            label: 'Скважина BM-002',
+            meta: {
+              distanceMeters: 2650,
+              activity: 'unknown',
+              match: 'unmatched',
+              matchSourceLabel: 'WellDB',
+              subtitle: 'ТО',
+              highlight: 'warning',
+              actions: [
+                {
+                  id: 'info',
+                  icon: <InfoOutlinedIcon fontSize="small" />,
+                  title: 'Подробнее',
+                  onClick: (node) => console.log('info', node.id),
+                },
+              ],
+            },
+          },
+          {
+            id: 'well-bm-003',
+            label: 'Скважина BM-003',
+            meta: { distanceMeters: 2780, activity: 'active', match: 'matched', matchSourceLabel: 'WellDB' },
+          },
+        ],
+      },
+      {
+        id: 'pad-bm-b',
+        label: 'Куст BM-Б',
+        meta: { distanceMeters: 2650, activity: 'stopped', match: 'partially' },
+        children: [],
+      },
+    ],
+  },
+  {
+    id: 'field-surgut',
+    label: 'Сургутское месторождение',
+    meta: { distanceMeters: 3200, activity: 'active', match: 'matched', matchSourceLabel: 'SAP' },
+    children: [
+      {
+        id: 'pad-sg-north',
+        label: 'Куст СГ-Северный',
+        meta: { distanceMeters: 3200, activity: 'active', match: 'partially' },
+        children: [],
+      },
+    ],
+  },
+  {
+    id: 'field-krasno',
+    label: 'Красноленинское месторождение',
+    meta: { distanceMeters: 2950, activity: 'active', match: 'unmatched' },
+  },
+  {
+    id: 'field-south',
+    label: 'Южное месторождение',
+    meta: { distanceMeters: 2400, activity: 'stopped', match: 'unmatched' },
+  },
+];
+
+const ExampleTreeUsage: React.FC = () => {
+  const [selected, setSelected] = React.useState<string | string[] | undefined>(undefined);
+  const [expanded, setExpanded] = React.useState<string[] | undefined>(['field-bm', 'pad-bm-a']);
+
+  const nodeContentSx = React.useCallback((node: TreeDataNode) => {
+    // Example: visually mark unmatched items
+    if (node.meta?.match === 'unmatched') {
+      return { borderColor: (theme) => theme.palette.error.dark, backgroundColor: (theme) => theme.palette.action.hover };
+    }
+    return undefined;
+  }, []);
+
+  const actionsRender = (node: TreeDataNode) => (
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+      <IconButton size="small" onClick={(e) => { e.stopPropagation(); console.log('link', node.id); }}>
+        <LinkIcon fontSize="inherit" />
+      </IconButton>
+      <IconButton size="small" onClick={(e) => { e.stopPropagation(); console.log('info', node.id); }}>
+        <InfoOutlinedIcon fontSize="inherit" />
+      </IconButton>
+    </Box>
+  );
+
+  // Custom label example to demonstrate full control over markup
+  const renderLabel = (node: TreeDataNode) => {
+    return (
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 1, minWidth: 0 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 0 }}>
+          <Box sx={statusDotSx} />
+          <Typography variant="body2" noWrap title={node.label}>
+            {node.label}
+          </Typography>
+        </Box>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          {node.meta?.matchSourceLabel && <Box component="span" sx={chipSx}>{node.meta.matchSourceLabel}</Box>}
+          <IconButton size="small" onClick={(e) => { e.stopPropagation(); console.log('custom info', node.id); }}>
+            <InfoOutlinedIcon fontSize="inherit" />
+          </IconButton>
+        </Box>
+      </Box>
+    );
+  };
+
+  return (
+    <Box>
+      <Typography variant="h6" gutterBottom>
+        Demo: Reusable MUI Tree
+      </Typography>
+      {/* Default label & behavior */}
+      <Tree
+        data={data}
+        multiSelect
+        nodeContentSx={nodeContentSx}
+        defaultExpanded={['field-bm', 'pad-bm-a']}
+        selected={selected}
+        onSelectedItemsChange={(e, ids) => setSelected(ids)}
+        expanded={expanded}
+        onExpandedItemsChange={(e, ids) => setExpanded(ids)}
+        // Icons example (could be replaced with custom SVGs)
+        collapseIcon={<CheckIcon fontSize="small" />}
+        expandIcon={<WarningAmberIcon fontSize="small" />}
+        endIcon={null}
+      />
+
+      <Box sx={{ mt: 3 }}>
+        <Typography variant="subtitle1" gutterBottom>
+          Кастомный renderLabel пример
+        </Typography>
+        <Tree
+          data={data}
+          renderLabel={renderLabel}
+          defaultExpanded={["field-bm"]}
+          endIcon={null}
+        />
+      </Box>
+    </Box>
+  );
+};
+
+export default ExampleTreeUsage;

--- a/src/components/Tree/README.md
+++ b/src/components/Tree/README.md
@@ -1,0 +1,45 @@
+# Reusable Tree Component (MUI X)
+
+Production-ready, typed and customizable wrapper around `@mui/x-tree-view` providing a simple API while allowing deep visual customization.
+
+## Files
+
+- `types.ts` — Shared TypeScript types
+- `utils.ts` — Helpers: `defaultGetChildren`, `hasChildren`, `mergeSx`
+- `styles.ts` — Sx constants and helpers
+- `CustomTreeItem.tsx` — Memoized wrapper around `TreeItem` with recursion
+- `Tree.tsx` — Wrapper around `SimpleTreeView`
+- `ExampleTreeUsage.tsx` — Demo with sample data
+
+## Installation
+
+```bash
+npm i @mui/material @mui/icons-material @mui/x-tree-view
+```
+
+## Usage
+
+```tsx
+import Tree from './Tree';
+import type { TreeDataNode } from './types';
+
+const data: TreeDataNode[] = [ /* ... */ ];
+
+<Tree data={data} multiSelect defaultExpanded={["root"]} />
+```
+
+## Props (TreeProps)
+- `data: TreeDataNode[]`
+- `renderLabel?: (node) => ReactNode`
+- `getChildren?: (node) => TreeDataNode[] | undefined`
+- `defaultExpanded?: string[]`, `expanded?: string[]`, `onExpandedItemsChange?`
+- `defaultSelectedItems?: string | string[]`, `selected?`, `onSelectedItemsChange?`
+- `multiSelect?: boolean`
+- `nodeContentSx?: (node) => SxProps`
+- `sx?: SxProps`
+- `collapseIcon?`, `expandIcon?`, `endIcon?`
+
+## Notes
+- Default label shows title, optional subtitle, status dot, distance, chips, and actions.
+- `node.meta.highlight` draws a left border using `highlightLeftBorder` helper.
+- You can pass your own `renderLabel` to fully control node markup.

--- a/src/components/Tree/Tree.tsx
+++ b/src/components/Tree/Tree.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import Box from '@mui/material/Box';
+import { SimpleTreeView } from '@mui/x-tree-view/SimpleTreeView';
+import type { TreeProps } from './types';
+import { defaultGetChildren } from './utils';
+import { treeSx } from './styles';
+import CustomTreeItem from './CustomTreeItem';
+
+const Tree: React.FC<TreeProps> = ({
+  data,
+  renderLabel,
+  getChildren = defaultGetChildren,
+  multiSelect,
+  nodeContentSx,
+  sx,
+  collapseIcon,
+  expandIcon,
+  endIcon,
+  // controlled / uncontrolled props
+  expanded,
+  onExpandedItemsChange,
+  defaultExpanded,
+  selected,
+  onSelectedItemsChange,
+  defaultSelectedItems,
+}) => {
+  return (
+    <Box sx={sx ? [treeSx, sx] : treeSx}>
+      <SimpleTreeView
+        slots={{}}
+        multiSelect={multiSelect}
+        expandedItems={expanded}
+        onExpandedItemsChange={onExpandedItemsChange}
+        defaultExpandedItems={defaultExpanded}
+        selectedItems={selected}
+        onSelectedItemsChange={onSelectedItemsChange}
+        defaultSelectedItems={defaultSelectedItems}
+      >
+        {data.map((node) => (
+          <CustomTreeItem
+            key={node.id}
+            node={node}
+            getChildren={getChildren}
+            renderLabel={renderLabel}
+            nodeContentSx={nodeContentSx}
+            collapseIcon={collapseIcon}
+            expandIcon={expandIcon}
+            endIcon={endIcon}
+          />
+        ))}
+      </SimpleTreeView>
+    </Box>
+  );
+};
+
+export default Tree;

--- a/src/components/Tree/styles.ts
+++ b/src/components/Tree/styles.ts
@@ -1,0 +1,145 @@
+import type { SxProps, Theme } from '@mui/material/styles';
+import { alpha } from '@mui/material/styles';
+import type { NodeMeta, TreeDataNode } from './types';
+
+export const treeSx: SxProps<Theme> = (theme) => ({
+  '--Tree-bg': theme.palette.mode === 'dark' ? alpha('#0b1220', 0.6) : '#fff',
+  '--Tree-border': theme.palette.divider,
+  '--Tree-radius': theme.shape.borderRadius,
+  '--Tree-item-hover': alpha(theme.palette.primary.main, 0.08),
+  '--Tree-item-selected': alpha(theme.palette.primary.main, 0.15),
+  '--Tree-item-focus': alpha(theme.palette.primary.main, 0.2),
+  p: 1,
+  borderRadius: 'calc(var(--Tree-radius) * 1px)',
+  '& .MuiTreeItem-root': {
+    position: 'relative',
+    mb: 1,
+    '&:last-of-type': { mb: 0 },
+  },
+});
+
+export const iconContainerSx: SxProps<Theme> = (theme) => ({
+  color: theme.palette.text.secondary,
+  display: 'flex',
+  alignItems: 'center',
+});
+
+export const treeItemContentBaseSx: SxProps<Theme> = (theme) => ({
+  bgcolor: 'var(--Tree-bg)',
+  border: '1px solid var(--Tree-border)',
+  borderRadius: 'calc(var(--Tree-radius) * 1px)',
+  px: 2,
+  py: 1,
+  display: 'flex',
+  alignItems: 'center',
+  gap: 1.5,
+  transition: theme.transitions.create(['background-color', 'box-shadow', 'border-color']),
+  '&:hover': { backgroundColor: 'var(--Tree-item-hover)' },
+  '&.Mui-selected': { backgroundColor: 'var(--Tree-item-selected)' },
+  '&.Mui-focused': { boxShadow: `0 0 0 2px ${alpha(theme.palette.primary.main, 0.2)}` },
+});
+
+export const labelSx: SxProps<Theme> = (theme) => ({
+  flex: 1,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  minWidth: 0,
+  '& .TreeLabel-left': {
+    display: 'flex',
+    alignItems: 'center',
+    minWidth: 0,
+    gap: 1,
+  },
+  '& .TreeLabel-title': {
+    fontWeight: 500,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+  '& .TreeLabel-subtitle': {
+    color: theme.palette.text.secondary,
+    fontSize: 12,
+  },
+  '& .TreeLabel-right': {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 1,
+  },
+});
+
+export const statusDotSx: SxProps<Theme> = (theme) => ({
+  width: 8,
+  height: 8,
+  borderRadius: '50%',
+  flex: '0 0 auto',
+  backgroundColor: theme.palette.text.disabled,
+  '&.active': { backgroundColor: theme.palette.success.main },
+  '&.stopped': { backgroundColor: theme.palette.warning.main },
+});
+
+export const chipSx: SxProps<Theme> = (theme) => ({
+  px: 1,
+  py: 0.25,
+  borderRadius: 1,
+  border: `1px solid ${alpha(theme.palette.primary.main, 0.4)}`,
+  color: theme.palette.primary.light,
+  backgroundColor: alpha(theme.palette.primary.main, 0.06),
+  fontSize: 12,
+});
+
+export const highlightLeftBorder = (meta?: NodeMeta): SxProps<Theme> => (theme) => {
+  if (!meta || !meta.highlight || meta.highlight === 'none') return undefined;
+  const colorMap: Record<string, string> = {
+    warning: theme.palette.warning.main,
+    error: theme.palette.error.main,
+    success: theme.palette.success.main,
+    info: theme.palette.info.main,
+  };
+  const color = colorMap[meta.highlight] ?? theme.palette.primary.main;
+  return {
+    position: 'relative',
+    '&:before': {
+      content: '""',
+      position: 'absolute',
+      left: 0,
+      top: 0,
+      bottom: 0,
+      width: 3,
+      borderTopLeftRadius: 'inherit',
+      borderBottomLeftRadius: 'inherit',
+      backgroundColor: color,
+    },
+    pl: 2, // compensate for the left border visual
+  } as const;
+};
+
+export const nodeRightActionsSx: SxProps<Theme> = () => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 0.75,
+  '& .TreeAction': {
+    cursor: 'pointer',
+    opacity: 0.9,
+    transition: 'opacity .2s',
+  },
+  '& .TreeAction[aria-disabled="true"]': {
+    pointerEvents: 'none',
+    opacity: 0.4,
+  },
+  '& .TreeAction:hover': {
+    opacity: 1,
+  },
+});
+
+export const emptyEndIconBoxSx: SxProps<Theme> = () => ({ width: 20, height: 20, display: 'inline-block' });
+
+export const nodeContentComposeSx = (
+  node: TreeDataNode,
+  base: SxProps<Theme>,
+  extra?: SxProps<Theme>,
+): SxProps<Theme> => {
+  const highlight = highlightLeftBorder(node.meta);
+  const final: SxProps<Theme> = [base, highlight, extra].filter(Boolean) as SxProps<Theme>;
+  return final;
+};

--- a/src/components/Tree/types.ts
+++ b/src/components/Tree/types.ts
@@ -1,0 +1,78 @@
+import type { ReactNode } from 'react';
+import type { SxProps, Theme } from '@mui/material/styles';
+
+// Basic status types to resemble the screenshot
+export type NodeActivityStatus = 'active' | 'stopped' | 'unknown';
+export type NodeMatchStatus = 'matched' | 'partially' | 'unmatched';
+
+export type TreeId = string;
+
+// Icon action configuration rendered to the right side of a node content
+export interface NodeAction {
+  id: string;
+  icon: ReactNode;
+  title?: string;
+  disabled?: boolean;
+  onClick?: (node: TreeDataNode, event: React.MouseEvent) => void;
+}
+
+// Meta information used by default label renderer and styles
+export interface NodeMeta {
+  distanceMeters?: number | null;
+  activity?: NodeActivityStatus; // colored dot
+  match?: NodeMatchStatus; // chip on the right
+  matchSourceLabel?: string; // e.g. "SAP", "WellDB"
+  subtitle?: string; // grey text below the main title
+  highlight?: 'warning' | 'success' | 'error' | 'info' | 'none'; // left border highlight
+  actions?: NodeAction[]; // right side action icons
+}
+
+export interface TreeDataNodeBase {
+  id: TreeId;
+  label: string; // used by default renderer; can be ignored when custom renderLabel is provided
+  meta?: NodeMeta;
+  // Optional raw children for simple use-cases. When not provided, use getChildren prop to load children.
+  children?: TreeDataNode[];
+}
+
+export type TreeDataNode = TreeDataNodeBase & Record<string, unknown>;
+
+export type GetChildren = (node: TreeDataNode) => TreeDataNode[] | undefined;
+export type RenderLabel = (node: TreeDataNode) => ReactNode;
+export type NodeContentSx = (node: TreeDataNode) => SxProps<Theme> | undefined;
+
+export interface TreeControlledSelectionProps {
+  selected?: string | string[];
+  onSelectedItemsChange?: (event: React.SyntheticEvent, ids: string | string[]) => void;
+  defaultSelectedItems?: string | string[];
+}
+
+export interface TreeControlledExpandedProps {
+  expanded?: string[];
+  onExpandedItemsChange?: (event: React.SyntheticEvent, ids: string[]) => void;
+  defaultExpanded?: string[];
+}
+
+// Main Tree component props
+export interface TreeProps extends TreeControlledSelectionProps, TreeControlledExpandedProps {
+  data: TreeDataNode[];
+  renderLabel?: RenderLabel;
+  getChildren?: GetChildren;
+  multiSelect?: boolean;
+  nodeContentSx?: NodeContentSx;
+  sx?: SxProps<Theme>;
+  // Optional global icons for expand/collapse/leaf
+  collapseIcon?: ReactNode;
+  expandIcon?: ReactNode;
+  endIcon?: ReactNode | null; // allow forcing an empty container to align contents
+}
+
+export interface CustomTreeItemProps {
+  node: TreeDataNode;
+  getChildren: GetChildren;
+  renderLabel?: RenderLabel;
+  nodeContentSx?: NodeContentSx;
+  collapseIcon?: ReactNode;
+  expandIcon?: ReactNode;
+  endIcon?: ReactNode | null;
+}

--- a/src/components/Tree/utils.ts
+++ b/src/components/Tree/utils.ts
@@ -1,0 +1,23 @@
+import type { SxProps, Theme } from '@mui/material/styles';
+import type { TreeDataNode, GetChildren } from './types';
+
+export const hasChildren = (node: TreeDataNode, getChildren: GetChildren): boolean => {
+  const children = getChildren(node);
+  return Array.isArray(children) && children.length > 0;
+};
+
+export const defaultGetChildren: GetChildren = (node) => node.children;
+
+// Merge sx props with array semantics
+export const mergeSx = (
+  base: SxProps<Theme> | undefined,
+  override: SxProps<Theme> | undefined,
+): SxProps<Theme> | undefined => {
+  if (!base) return override;
+  if (!override) return base;
+  return Array.isArray(base) ? [...base, override] : [base, override];
+};
+
+// Utility to build className list
+export const cx = (...classes: Array<string | false | null | undefined>): string =>
+  classes.filter(Boolean).join(' ');


### PR DESCRIPTION
Introduce a reusable and highly customizable `Tree` component based on `@mui/x/react-tree-view`.

---
<a href="https://cursor.com/background-agent?bcId=bc-b865d529-48aa-44a4-a90a-1bf9022d0db3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b865d529-48aa-44a4-a90a-1bf9022d0db3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

